### PR TITLE
Do not terminates at first error

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,16 +18,21 @@ type Config struct {
 // Define variable
 var isError bool = false
 
-// failf prints an error.
-func failf(format string, args ...interface{}) {
+// printError prints an error.
+func printError(format string, args ...interface{}) {
 	log.Errorf(format, args...)
-	isError = true
 }
 
-// errorf prints an error and terminates step
-func errorf(format string, args ...interface{}) {
-	log.Errorf(format, args...)
+// abortf prints an error and terminates step
+func abortf(format string, args ...interface{}) {
+	printError(format, args...)
 	os.Exit(1)
+}
+
+// setOperationFailed marked step as failed
+func setOperationFailed(format string, args ...interface{}) {
+	printError(format, args...)
+	isError = true
 }
 
 func stopInstance(wg *sync.WaitGroup, uuid string) {
@@ -36,7 +41,9 @@ func stopInstance(wg *sync.WaitGroup, uuid string) {
 	cmd := command.New("gmsaas", "instances", "stop", uuid)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		failf("Failed to stop instance %s, error: error: %s | output: %s", uuid, cmd.PrintableCommandArgs(), err, out)
+		setOperationFailed("Failed to stop instance %s, error: error: %s | output: %s", uuid, cmd.PrintableCommandArgs(), err, out)
+		return
+
 	}
 	log.Donef("Instance stopped %s", uuid)
 }
@@ -44,7 +51,7 @@ func stopInstance(wg *sync.WaitGroup, uuid string) {
 func main() {
 	var c Config
 	if err := stepconf.Parse(&c); err != nil {
-		errorf("Issue with input: %s", err)
+		abortf("Issue with input: %s", err)
 	}
 	stepconf.Print(c)
 

--- a/main.go
+++ b/main.go
@@ -15,8 +15,17 @@ type Config struct {
 	GMCloudSaaSInstanceUUID string `env:"instance_uuid,required"`
 }
 
-// failf prints an error and terminates the step.
+// Define variable
+var isError bool = false
+
+// failf prints an error.
 func failf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
+	isError = true
+}
+
+// errorf prints an error and terminates step
+func errorf(format string, args ...interface{}) {
 	log.Errorf(format, args...)
 	os.Exit(1)
 }
@@ -35,7 +44,7 @@ func stopInstance(wg *sync.WaitGroup, uuid string) {
 func main() {
 	var c Config
 	if err := stepconf.Parse(&c); err != nil {
-		failf("Issue with input: %s", err)
+		errorf("Issue with input: %s", err)
 	}
 	stepconf.Print(c)
 
@@ -55,5 +64,9 @@ func main() {
 	// The exit code of your Step is very important. If you return
 	//  with a 0 exit code `bitrise` will register your Step as "successful".
 	// Any non zero exit code will be registered as "failed" by `bitrise`.
+	if isError {
+		// If at least one error happens, step will fail
+		os.Exit(1)
+	}
 	os.Exit(0)
 }


### PR DESCRIPTION
As we can stop several instances in parrallel we do not want to terminate the step if an error happens.
So let's the step makes all the job and mark it as Failed if at least one error occurs.

see also https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-start/pull/9